### PR TITLE
Fix/edita deleta turma

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -30,7 +30,7 @@ $routes->group('sys', function ($routes) {
         $routes->get('', 'TurmaController::index');
         $routes->post('create', 'TurmaController::create');
         $routes->post('update', 'TurmaController::update');
-        $routes->delete('delete', 'TurmaController::delete');
+        $routes->post('delete', 'TurmaController::delete');
         $routes->post('import', 'TurmaController::import');
         $routes->post('importProcess', 'TurmaController::importProcess'); 
     });

--- a/app/Views/components/turmas/modal_deletar_turma.php
+++ b/app/Views/components/turmas/modal_deletar_turma.php
@@ -1,23 +1,46 @@
 <div class="modal fade" id="modal-deletar-turma" tabindex="-1" aria-labelledby="modal-deletar-turma-label" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
+
             <div class="modal-header">
                 <h5 class="modal-title" id="modal-deletar-turma-label">Confirmação de Exclusão</h5>
                 <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">×</span>
                 </button>
             </div>
-            <form id="turmaFormDeletar" method="post" action="<?= base_url('sys/turmas/deletar') ?>">
+
+            <form id="turmaFormDeletar" method="post" action="<?= base_url('sys/turmas/delete') ?>">
+                <?= csrf_field() ?>
+
                 <div class="modal-body">
-                    <?= csrf_field() ?>
+                    
                     <input type="hidden" name="id" id="deleteTurmaId">
-                    <p class="text-break">Confirma a exclusão da turma <b id='deletar-nome'></b></p>
+                    <p class="text-break">Confirma a exclusão da turma <strong id='deletar-nome'></strong>?</p>
                 </div>
+
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                     <button type="submit" class="btn btn-danger">Excluir Turma</button>
                 </div>
             </form>
+
         </div>
     </div>
 </div>
+
+<script>
+    $(document).ready(function() {
+
+        $("#modal-deletar-turma").on("show.bs.modal", function(event) {
+            var button = $(event.relatedTarget);
+
+            var id = button.data("id");
+            var nome = button.data("nome");
+
+            var modal = $(this);
+            modal.find("#deleteTurmaId").val(id);
+            modal.find("#deletar-nome").text(nome);
+        });
+
+    });
+</script>

--- a/app/Views/components/turmas/modal_editar_turma.php
+++ b/app/Views/components/turmas/modal_editar_turma.php
@@ -1,39 +1,63 @@
-<div class="modal fade modal-xl" id="modal-editar-turma" tabindex="-1" role="dialog" aria-labelledby="modal-editar-turma-label" aria-hidden="true">
+<div class="modal fade" id="modal-editar-turma" tabindex="-1" role="dialog" aria-labelledby="modal-editar-turma-label" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
+
             <div class="modal-header">
                 <h5 class="modal-title" id="modal-editar-turma-label">Editar Turma</h5>
                 <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">×</span>
                 </button>
             </div>
-            <form id="editarTurma" class="forms-sample" method="post" action="<?= base_url('sys/turmas/atualizar') ?>">
+
+            <form id="editarTurma" class="forms-sample" method="post" action="<?= base_url('sys/turmas/update') ?>">
+                <?= csrf_field() ?>
+
                 <div class="modal-body">
-                    <?= csrf_field() ?>
+                    
                     <input type="hidden" name="id" id="editTurmaId" />
-                    <div class="row">
-                        <div class="form-group">
-                            <label for="edit-nome">Nome</label>
-                            <input type="text" class="form-control" required
-                                id="edit-nome" name="nome" placeholder="Insira o nome da Turma">
-                        </div>
-                        <div class="col-md-6 col-sm-12">
-                            <div class="form-group">
-                                <label for="edit-curso_id">Curso</label>
-                                <select class="form-select" id="edit-curso_id" name="curso_id" required>
-                                    <?php foreach ($cursos as $curso): ?>
-                                        <option value="<?= esc($curso['id']) ?>"><?= esc($curso['nome']) ?></option>
-                                    <?php endforeach; ?>
-                                </select>
-                            </div>
-                        </div>
+
+                    
+                    <div class="form-group">
+                        <label for="edit-nome">Nome</label>
+                        <input type="text" class="form-control" required
+                            id="edit-nome" name="nome" placeholder="Insira o nome da Turma">
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="edit-curso_id">Curso</label>
+                        <select class="form-select" id="edit-curso_id" name="curso_id" required>
+                            <?php foreach ($cursos as $curso): ?>
+                                <option value="<?= esc($curso['id']) ?>"><?= esc($curso['nome']) ?></option>
+                            <?php endforeach; ?>
+                        </select>
                     </div>
                 </div>
+
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                     <button type="submit" class="btn btn-primary">Salvar</button>
                 </div>
             </form>
+
         </div>
     </div>
 </div>
+
+<script>
+    $(document).ready(function() {
+
+        $("#modal-editar-turma").on("show.bs.modal", function(event) {
+            var button = $(event.relatedTarget);
+
+            var nome = button.data("nome");
+            var id = button.data("id");
+            var curso_id = button.data("curso_id");
+
+            var modal = $(this);
+            modal.find("#editTurmaId").val(id);
+            modal.find("#edit-nome").val(nome);
+            modal.find("#edit-curso_id").val(curso_id);
+        });
+
+    });
+</script>


### PR DESCRIPTION
Mudei a rota do deletar de turma que estava como delete ao invés de post;
Nos modais de excluir e editar turma estava faltando os javascript e as rotas dos formulários estavam desatualizadas;
O modal de editar também estava desconfigurado e já ajeitei. 

Essa é a correção do erro do deletar e editar turmas apontado no relatório do João