### PR TITLE
feat: Adiciona os perfis do sistema. 

### DIFF
--- a/app/Config/AuthGroups.php
+++ b/app/Config/AuthGroups.php
@@ -49,6 +49,18 @@ class AuthGroups extends ShieldAuthGroups
             'title'       => 'Admin',
             'description' => 'Day to day administrators of the site.',
         ],
+        'solicitante' => [
+            'title' => 'Solicitante',
+            'description' => 'Pode solicitar refeições.',
+        ],
+        'restaurante' => [
+            'title' => 'Restaurante',
+            'description' => 'Pode visulizar relatórios de refeições.',
+        ],
+        'aluno' => [
+            'title' => 'Aluno',
+            'description' => 'Pode confirmar refeições.',
+        ],
         'developer' => [
             'title'       => 'Developer',
             'description' => 'Site programmers.',
@@ -78,6 +90,7 @@ class AuthGroups extends ShieldAuthGroups
         'users.create'        => 'Can create new non-admin users',
         'users.edit'          => 'Can edit existing non-admin users',
         'users.delete'        => 'Can delete existing non-admin users',
+        'solicitante.view'    => 'Pode visualizar a lista de solicitações', //exemplo de permissão
         'beta.access'         => 'Can access beta-level features',
     ];
 
@@ -101,6 +114,19 @@ class AuthGroups extends ShieldAuthGroups
             'users.edit',
             'users.delete',
             'beta.access',
+        ],
+        'solicitante' => [
+            'solicitacoes.view',
+            'solicitacoes.create',
+            'solicitacoes.delete',
+            'solicitacoes.edit',
+        ],
+        'restaurante' => [
+            'relatorios.view',
+        ],
+        'aluno' => [
+            'confirmacao.view',
+            'confirmacao.create',
         ],
         'developer' => [
             'admin.access',


### PR DESCRIPTION
Foi adicionado os perfis do sistema, mas ainda deve ser configurada suas permissões. 

Para configurar as permissões é feito da seguinte maneira:

definição dos perfis com as suas permissões:

`'solicitante' => [`    

`'solicitacoes.view',`    

`'solicitacoes.create',`   

 `'solicitacoes.delete',`    

`'solicitacoes.edit',`

`]`

array de permisoes em AuthGroup: 
`'solicitante.view'    => 'Pode visualizar a lista de solicitações',  //exemplo de permissão`

ROTA: 

para apenas uma rota: 
`$routes->get('', 'CursoController::index', ['filter' => 'permission:cursos.view']); //adiciona a permissão na rota` 

para todo um grupo: 

`$routes->group('turmas', ['filter' => 'admin'], static function ($routes) {`    

`$routes->get('', 'TurmaController::index');`    

`$routes->post('create', 'TurmaController::create');`    

`$routes->post('update', 'TurmaController::update');`    

`$routes->post('delete', 'TurmaController::delete');`    

`$routes->post('import', 'TurmaController::import');`    

`$routes->post('importProcess', 'TurmaController::importProcess'); });`

No sistema PlanIFica a funções de gestão de usuário é escondida pelo front-end usando php para ser acessada apenas pelo admin. 