### PR TITLE
Adicionando a rota do admin

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -110,4 +110,20 @@ $routes->group('sys', function ($routes) {
         $routes->get('nao-servidos', 'RelatorioController::refeicoesNaoServidas');
         $routes->get('confirmados', 'RelatorioController::confirmados');
     });
+
+    //==============================================================
+    // Rotas do Admin para o gerenciamento de usuários
+    //==============================================================
+
+    $routes->group('admin', function ($routes) {
+        $routes->get('/', 'AdminController::index'); // Página inicial da admin
+        $routes->post('alterar-grupo', 'AdminController::alterarGrupoUsuario'); // Atribuir a um grupo de usuários
+        $routes->post('atualizar-usuario', 'AdminController::atualizarUsuario'); 
+        $routes->post('resetar-senha', 'AdminController::resetarSenha'); // Atualizar senha
+        $routes->post('desativar-usuario', 'AdminController::desativarUsuario');
+        $routes->post('registrar-usuario', 'AdminController::registrarUsuario');
+        $routes->get('usuarios-inativos', 'AdminController::usuariosInativos');
+        $routes->post('reativar-usuario', 'AdminController::reativarUsuario');
+        $routes->post('excluir-permanentemente', 'AdminController::excluirPermanentemente');
+    });
 });


### PR DESCRIPTION
Adicionei a rota do administrador para ter acesso à tela de gerenciamento de usuários do sistema. Fiz essa rota apenas para preparar o ambiente e criar o front-end da aba "Usuários do Sistema", já que no dashbord.php, para ter acesso a tela o href é <?php echo base_url('sys/admin'); ?>.  Utilizei a rota semelhante ao PlanIFica.