### PR TITLE
Padronização do AdminController.php

### DIFF
--- a/app/Controllers/AdminController.php
+++ b/app/Controllers/AdminController.php
@@ -3,66 +3,26 @@
 namespace App\Controllers;
 
 use App\Controllers\BaseController;
-use CodeIgniter\Shield\Models\UserModel;
+use App\Models\UserModel;
 use CodeIgniter\Shield\Entities\User;
-use CodeIgniter\Shield\Models\GroupModel;
+use App\Models\GroupModel; // Importando a tabela 'auth_groups_users' para buscar um grupo pelo nome
+use App\Models\UserGroupModel; // Importando a tabela 'auth_groups_users'
 use CodeIgniter\Shield\Entities\Group;
 use CodeIgniter\Shield\Authentication\Passwords;
 
 class AdminController extends BaseController
 {
 
+    protected $groupModel;
     protected $userModel;
-    protected $table = 'auth_groups_users'; // tabela de associação entre usuários e grupos
+    protected $userGroupModel;
 
     public function __construct()
     {
-        $this->userModel = new UserModel();
+        $this->groupModel = new GroupModel();  // Carregando o modelo de grupos
+        $this->userGroupModel = new UserGroupModel();  // Carregando o modelo de associação de usuários a grupos
+        $this->userModel = new UserModel();  // Carregando o modelo de usuários do CodeIgniter Shield
 
-    }
-
-    public function getUserGroups($userId) // obtém os grupos de um usuário específico
-    {
-        $db = \Config\Database::connect();
-        return $db->table($this->table)
-                  ->where('user_id', $userId)
-                  ->get()
-                  ->getResult(); // retorna array de objetos
-    }
-
-    public function getGroupByName($groupName) // obtém um grupo pelo nome
-    {
-        $db = \Config\Database::connect();
-        return $db->table($this->table)
-                  ->where('group', $groupName)
-                  ->get()
-                  ->getRow(); // retorna o primeiro resultado como objeto
-    }
-
-    public function addUserToGroup($userId, $group, $createdAt = null)
-    {
-        $db = \Config\Database::connect();
-        $builder = $db->table('auth_groups_users');
-
-        if (empty($userId) || empty($group)) {
-            log_message('error', 'ID do usuário ou grupo inválido.');
-            return false;
-        }
-
-        $data = [
-            'user_id' => $userId,
-            'group' => $group,
-            'created_at' => $createdAt ?? date('Y-m-d H:i:s'),
-        ];
-
-        try {
-            $builder->insert($data);
-            log_message('info', "Usuário $userId adicionado ao grupo $group com sucesso.");
-            return true;
-        } catch (\Exception $e) {
-            log_message('error', "Erro ao adicionar usuário ao grupo: " . $e->getMessage());
-            return false;
-        }
     }
 
     public function index()
@@ -70,38 +30,13 @@ class AdminController extends BaseController
         $usuarios = $this->gerenciarUsuarios();
         $data['usuarios'] = $usuarios;
 
-        $data['content'] = view('sys/gerenciar-usuarios', ['usuarios' => $usuarios]);
-        return view('dashboard', $data);
+        $this->content_data['content'] = view('sys/gerenciar-usuarios', $data);
+        return view('dashboard', $this->content_data);
     }
 
     public function gerenciarUsuarios()
     {
-        // Pega todos os usuários
-        $usuarios = $this->userModel->select('id, username')->findAll();
-
-        $db = \Config\Database::connect();
-        $builderGrupos = $db->table('auth_groups_users'); // tabela de grupos
-        $builderIdentities = $db->table('auth_identities'); // tabela de emails
-
-        foreach ($usuarios as &$usuario) {
-            // Pega o email do usuário na tabela auth_identities
-            $emailRow = $builderIdentities
-                ->select('secret')
-                ->where('user_id', $usuario->id)
-                ->where('type', 'email_password') // filtra só o e-mail
-                ->get()
-                ->getRow();
-
-            $usuario->email = $emailRow ? $emailRow->secret : '';
-
-            // Pega os grupos do usuário
-            $grupos = $builderGrupos
-                ->where('user_id', $usuario->id)
-                ->get()
-                ->getResult();
-
-            $usuario->grupos = array_map(fn($grupo) => $grupo->group, $grupos);
-        }
+        $usuarios = $this->userModel->getUsuariosComGrupos(); // Pega todos os usuários com grupo -> Puxa do UserModel.php
 
         return $usuarios;
     }
@@ -114,12 +49,9 @@ class AdminController extends BaseController
             'password' => $this->request->getPost('password'),
         ];
 
-        $existingUsername = $this->userModel->where('username', $data['username'])->first();
-        $existingEmail = $this->userModel->db->table('auth_identities')
-            ->where('type', 'email_password') // Tipo de identidade (e-mail)
-            ->where('secret', $data['email']) // O e-mail está armazenado na coluna `secret`
-            ->get()
-            ->getRow();
+        $existingUsername = $this->userModel->findByUsername($data['username']); // Pega o método do UserModel.php
+        $existingEmail = $this->userModel->findByEmail($data['email']); // Pega o método do UserModel.php
+
 
         $errorMessage = '';
 
@@ -150,7 +82,7 @@ class AdminController extends BaseController
         $grupo = $this->request->getPost('grupo');
 
         if ($grupo) {
-            if (!$this->addUserToGroup($userId, $grupo)) {
+            if (!$this->userGroupModel->addUserToGroup($userId, $grupo)) {
                 log_message('error', "Erro ao vincular o usuário $userId ao grupo $grupo.");
             } else {
                 log_message('info', "Usuário $userId vinculado ao grupo $grupo com sucesso.");
@@ -205,17 +137,9 @@ class AdminController extends BaseController
         if (!$userId || !$novoGrupo) {
             return redirect()->to('/sys/admin/')->with('error', 'Usuário ou grupo inválido.');
         }
-
-        $db = \Config\Database::connect();
-        $builderGrupos = $db->table('auth_groups_users');
-        $builderGroups = $db->table('auth_groups');
-
+        
         // Verifica se o usuário já pertence ao grupo
-        $userGroup = $builderGrupos
-            ->where('user_id', $userId)
-            ->where('group', $novoGrupo)
-            ->get()
-            ->getRow();
+        $userGroup = $this->userGroupModel->where('user_id', $userId)->where('group', $novoGrupo)->first();
 
         // Se o usuário já pertence ao grupo, nada precisa ser feito
         if ($userGroup) {
@@ -223,21 +147,18 @@ class AdminController extends BaseController
             return redirect()->to('/sys/admin/')->with('info', 'Usuário já pertence ao grupo.');
         }
 
-        // Pega o grupo atual do usuário
-        $userCurrentGroup = $builderGrupos
-            ->where('user_id', $userId)
-            ->get()
-            ->getRow();
+        // Se o usuário pertence a um grupo que não está mais no banco, não gera erro, só substitui
+        $userCurrentGroup = $this->userGroupModel->where('user_id', $userId)->first();
+
+        if ($userCurrentGroup && !$this->groupModel->getGroupByName($userCurrentGroup['group'])) {
+            log_message('info', "Usuário $userId pertence a um grupo não registrado no banco. Substituindo o grupo.");
+        }
 
         // Remove o usuário de todos os grupos antes de adicionar ao novo grupo
-        $builderGrupos->where('user_id', $userId)->delete();
+        $this->userGroupModel->where('user_id', $userId)->delete();
 
         // Adiciona o usuário ao novo grupo
-        $result = $builderGrupos->insert([
-            'user_id'    => $userId,
-            'group'      => $novoGrupo,
-            'created_at' => date('Y-m-d H:i:s'),
-        ]);
+        $result = $this->userGroupModel->addUserToGroup($userId, $novoGrupo);
 
         if (!$result) {
             log_message('error', "Falha ao alterar grupo do usuário: $userId para $novoGrupo");
@@ -285,19 +206,8 @@ class AdminController extends BaseController
                 ->with('error', ['Usuário não encontrado.']);
         }
 
-        // Verifica se já existe um usuário com o mesmo username (exceto o próprio usuário)
-        $existingUsername = $this->userModel
-            ->where('username', $username)
-            ->where('id !=', $userId)
-            ->first();
-
-        // Verifica se já existe um usuário com o mesmo e-mail (exceto o próprio usuário)
-        $existingEmail = $this->userModel->db->table('auth_identities')
-            ->where('type', 'email_password')
-            ->where('secret', $email)
-            ->where('user_id !=', $userId)
-            ->get()
-            ->getRow();
+        $existingUsername = $this->userModel->findByUsername($username, $userId); // Pega o método do UserModel.php
+        $existingEmail = $this->userModel->findByEmail($email, $userId); // Pega o método do UserModel.php
 
         // Verifica se há conflitos de username ou e-mail
         if ($existingUsername && $existingEmail) {

--- a/app/Models/GroupModel.php
+++ b/app/Models/GroupModel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class GroupModel extends Model
+{
+    protected $table = 'auth_groups_users';  // O nome da tabela que contém os grupos
+    protected $primaryKey = 'id'; // Supondo que a chave primária seja 'id'
+    protected $allowedFields = ['user_id'];  // Ou outros campos que a tabela 'groups' tenha
+
+    // Método para buscar um grupo pelo nome
+    public function getGroupByName($groupName)
+    {
+        return $this->where('group', $groupName)->first();
+    }
+}

--- a/app/Models/UserGroupModel.php
+++ b/app/Models/UserGroupModel.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class UserGroupModel extends Model
+{
+    protected $table = 'auth_groups_users'; // Tabela do Shield
+    protected $allowedFields = ['user_id', 'group', 'created_at']; // Campos permitidos
+    protected $useTimestamps = false; // Gerenciamento automático de timestamps
+
+    /**
+     * Retorna todos os grupos de um usuário.
+     */
+    public function getUserGroups($userId)
+    {
+        return $this->where('user_id', $userId)->findAll();
+    }
+
+    /**
+     * Adiciona um usuário a um grupo (sem necessidade de verificação prévia).
+     */
+    public function addUserToGroup($userId, $group, $createdAt = null)
+    {
+        if (empty($userId) || empty($group)) {
+            log_message('error', 'ID do usuário ou grupo inválido.');
+            return false;
+        }
+
+        // Prepare os dados para inserção
+        $data = [
+            'user_id' => $userId,
+            'group' => $group,
+            'created_at' => $createdAt ?? date('Y-m-d H:i:s'),
+        ];
+
+        // Tente inserir o novo grupo
+        try {
+            $this->insert($data);
+            log_message('info', "Usuário $userId adicionado ao grupo $group com sucesso.");
+            return true;
+        } catch (\Exception $e) {
+            log_message('error', "Erro ao adicionar usuário ao grupo: " . $e->getMessage());
+            return false;
+        }
+    }
+}

--- a/app/Models/UserModel.php
+++ b/app/Models/UserModel.php
@@ -18,4 +18,43 @@ class UserModel extends ShieldUserModel
             // 'first_name',
         ];
     }
+
+    public function getUsuariosComGrupos() // Seleciona todos os usuários com grupos OBS: Se não tiver grupo, também aparece na view "Nenhum grupo atribuído"
+    {
+        
+        $usuarios = $this->select('id, username')->findAll();
+
+        $userGroupModel = model(UserGroupModel::class);
+
+        foreach ($usuarios as &$usuario) {
+            $grupos = $userGroupModel->getUserGroups($usuario->id);
+            $usuario->grupos = array_column($grupos, 'group');
+        }
+
+        return $usuarios;
+    }
+
+    public function findByUsername(string $username, ?int $ignoreUserId = null) // Procura o nome do Usuário
+    {
+        $builder = $this->where('username', $username);
+        if ($ignoreUserId) {
+            $builder->where('id !=', $ignoreUserId);
+        }
+        return $builder->first();   
+    }
+
+    public function findByEmail(string $email, ?int $ignoreUserId = null) // Procura o E-mail do usuário
+    {
+        $builder = $this->db->table('auth_identities')
+            ->where('type', 'email_password')
+            ->where('secret', $email);
+
+        if ($ignoreUserId) {
+            $builder->where('user_id !=', $ignoreUserId);
+        }
+
+        return $builder->get()->getRow();
+    }
+
+
 }


### PR DESCRIPTION
Como estava mexendo na tela de gerenciamento de usuários, eu padronizei o AdminController, que era o controller que eu estava utilizando para a tela de gerenciamento. Criei 2 arquivos no Models referente as tabelas do shield. Fiz separados para puxar no controller e padronizar, isso evitar fazer consultas sql no controller. Além disso modifiquei o arquivo UserModel.php, e adicionei 3 funções: getUsuariosComGrupos (Seleciona todos os usuários com grupos), findByUsername (Procura o nome do Usuário) e findByEmail (Procura o E-mail do usuário). Com essas funções eu só fiz puxar no controler para evitar consulta sql que verifica se os usuários tem o mesmo nome ou email.